### PR TITLE
Improve train simulator automation and controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.DS_Store


### PR DESCRIPTION
## Summary
- integrate microphone preparation into the start flow and drive steps through speech recognition with optional automatic or prompted advancement
- refresh the trainer controls with a two-button layout, advance mode toggle, and completion prompt while updating scoring to focus on Iceman lines
- add a gitignore to exclude build artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca39ba0600832b9b7c6bc619c6d542