### PR TITLE
Adjust speech recognition max duration

### DIFF
--- a/lib/speech.js
+++ b/lib/speech.js
@@ -29,7 +29,7 @@ export function makeRecognizer() {
  */
 export function listenOnce({
   minMs = 1200,
-  maxMs = 15000,
+  maxMs = 20000,
   silenceMs = 2500,
   onInterim = () => {},
   onStatus = () => {},


### PR DESCRIPTION
## Summary
- raise the `listenOnce` speech recognition max duration to 20 seconds to allow longer captures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca424c0994832ba459aafd67b78a7f