### PR TITLE
Simplify mobile layout visuals

### DIFF
--- a/pages/train.js
+++ b/pages/train.js
@@ -60,15 +60,14 @@ function renderToasts() {
   if (!host) { host = document.createElement("div"); host.id = "pm-toast-host"; host.className = "pm-toasts"; document.body.appendChild(host); }
   host.innerHTML = _toasts.map(t => `<div class="pm-toast ${t.kind}">${t.msg}</div>`).join("");
 }
-function useResponsiveMode(forced = null) {
+function useResponsiveMode() {
   const pick = () => (window.innerWidth <= 860 ? "mobile" : "desktop");
-  const [mode, setMode] = useState(typeof window === "undefined" ? "desktop" : forced || pick());
+  const [mode, setMode] = useState(() => (typeof window === "undefined" ? "desktop" : pick()));
   useEffect(() => {
-    if (forced) { setMode(forced); return; }
     const onResize = () => setMode(pick());
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, [forced]);
+  }, []);
   return mode;
 }
 function downloadCSV(rows, filename = "deice-results.csv") {
@@ -100,8 +99,7 @@ export default function TrainPage() {
   const [awaitingAdvance, setAwaitingAdvance] = useState(false);
   const [resultsVersion, setResultsVersion] = useState(0);
 
-  const [forcedMode, setForcedMode] = useState(null);
-  const mode = useResponsiveMode(forcedMode);
+  const mode = useResponsiveMode();
 
   const runningRef = useRef(false);
   const pausedRef = useRef(false);
@@ -438,8 +436,8 @@ function onPause() {
             <h1>Deice Verbiage Trainer</h1>
             <span className="pm-badge">V1 • OMA • Training use only</span>
           </div>
-          <div className="pm-row">
-            <div className="pm-row">
+          <div className="pm-headerControls">
+            <div className="pm-row pm-scenarioControl">
               <span className="pm-label">Scenario</span>
               <select
                 className="pm-select"
@@ -467,16 +465,10 @@ function onPause() {
                 {(scenarioList || []).map(s => <option key={s.id} value={s.id}>{s.label}</option>)}
               </select>
             </div>
-
-            <div className="pm-row" style={{ marginLeft: 8 }}>
-              <span className="pm-label">View</span>
-              <button className="pm-btn ghost" onClick={() => setForcedMode(null)}>Auto</button>
-              <button className="pm-btn ghost" onClick={() => setForcedMode("desktop")}>Desktop</button>
-              <button className="pm-btn ghost" onClick={() => setForcedMode("mobile")}>Mobile</button>
+            <div className="pm-statusGroup">
+              <span className="pm-pill">{status}</span>
+              <span className="pm-pill">Captain: {captainStatus}</span>
             </div>
-
-            <span className="pm-pill" style={{ marginLeft: 8 }}>{status}</span>
-            <span className="pm-pill" style={{ marginLeft: 8 }}>Captain: {captainStatus}</span>
           </div>
         </div>
 
@@ -484,11 +476,11 @@ function onPause() {
         <div className={`pm-main ${mode}`}>
           {/* LEFT */}
           <section className="pm-panel">
-            <div className="pm-row" style={{ justifyContent: "space-between", flexWrap: "wrap", gap: 8 }}>
-              <div className="pm-row" style={{ flexWrap: "wrap", gap: 8 }}>
+            <div className="pm-runRow">
+              <div className="pm-row pm-startControls">
                 <button type="button" className="pm-btn" onClick={onStart}>Start</button>
                 <button type="button" className="pm-btn ghost" onClick={onPause}>Pause</button>
-                <div className="pm-row" style={{ marginLeft: 12, gap: 6, flexWrap: "wrap" }}>
+                <div className="pm-row pm-advanceToggle">
                   <span className="pm-label">Advance</span>
                   <button
                     type="button"
@@ -524,7 +516,7 @@ function onPause() {
               </div>
             </div>
 
-            <div className="pm-row" style={{ marginTop: 8 }}>
+            <div className="pm-row pm-navRow" style={{ marginTop: 8 }}>
               <button className="pm-btn" onClick={() => {
                 resolvePrompt({ silent: true });
                 setStepIndex(i => {
@@ -554,14 +546,14 @@ function onPause() {
             <div style={{ marginTop: 10 }}>
               <div className="pm-label">Your Response</div>
               <textarea rows={3} className="pm-input" value={answer} onChange={e => setAnswer(e.target.value)} placeholder="Speak or type your line…" />
-              <div className="pm-row" style={{ marginTop: 6 }}>
+              <div className="pm-row pm-checkRow" style={{ marginTop: 6 }}>
                 <button className="pm-btn" onClick={onCheck}>Check</button>
                 <span className="pm-pill">{lastResultText}</span>
               </div>
             </div>
 
             {awaitingAdvance && (
-              <div className="pm-row" style={{ marginTop: 8 }}>
+              <div className="pm-row pm-awaitRow" style={{ marginTop: 8 }}>
                 <span className="pm-pill">Response captured. Proceed when ready.</span>
                 <button
                   className="pm-btn primary"
@@ -580,7 +572,7 @@ function onPause() {
 
           {/* RIGHT */}
           <section className="pm-panel">
-            <div className="pm-row" style={{ justifyContent: "space-between" }}>
+            <div className="pm-row pm-progressRow">
               <div>
                 <div className="pm-label">Progress</div>
                 <Stepper total={total} current={Math.max(0, stepIndex)} results={resultsRef.current || []}
@@ -606,7 +598,7 @@ function onPause() {
               <div className="pm-log">{logText}</div>
             </div>
 
-            <div className="pm-row" style={{ marginTop: 10, justifyContent: "flex-end" }}>
+            <div className="pm-row pm-exportRow" style={{ marginTop: 10 }}>
               <button className="pm-btn ghost" onClick={exportSession}>Export CSV</button>
               <button className="pm-btn ghost" onClick={() => toast("Saved settings","success")}>Save Settings</button>
             </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -95,6 +95,16 @@ body.piedmont {
 .pm-main.desktop { grid-template-columns: 1.25fr .9fr; }
 .pm-main.mobile  { grid-template-columns: 1fr; }
 
+.pm-headerControls { display:flex; align-items:center; justify-content:flex-end; gap:12px; flex-wrap:wrap; }
+.pm-scenarioControl { align-items:center; gap:8px; }
+.pm-statusGroup { display:flex; align-items:center; gap:8px; flex-wrap:wrap; justify-content:flex-end; }
+.pm-runRow { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; flex-wrap:wrap; }
+.pm-startControls { gap:8px; align-items:center; flex-wrap:wrap; }
+.pm-advanceToggle { gap:6px; align-items:center; flex-wrap:wrap; }
+.pm-navRow, .pm-checkRow, .pm-awaitRow { gap:8px; align-items:center; flex-wrap:wrap; }
+.pm-progressRow { justify-content:space-between; align-items:flex-start; gap:12px; flex-wrap:wrap; }
+.pm-exportRow { justify-content:flex-end; gap:10px; flex-wrap:wrap; }
+
 /* panels */
 .pm-panel { background: #e2e8f0; border: 1px solid var(--border); border-radius: 12px; padding: 12px; }
 .pm-row { display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
@@ -151,5 +161,37 @@ body.piedmont {
 
 /* responsive */
 @media (hover:none) and (pointer:coarse){ .pm-btn, .pm-select, .pm-input, textarea { min-height:44px } }
-@media (max-width: 860px){ .pm-main{ padding:12px } .pm-log{ height:140px } body.piedmont{ background-size: 600px auto } }
-@media (max-width: 480px){ .pm-log{ height:120px } body.piedmont{ background-position: right -10px top -10px } }
+@media (max-width: 860px){
+  .pm-main{ padding:12px }
+  .pm-log{ height:140px }
+  body.piedmont{ background:#000; background-image:none; }
+}
+@media (max-width: 720px){
+  .pm-app{ margin:16px auto; padding:0 12px; }
+  .pm-card{ border-radius:14px; }
+  .pm-header{ flex-direction:column; align-items:flex-start; gap:12px; }
+  .pm-title{ flex-wrap:wrap; gap:10px; }
+  .pm-title img{ height:110px; }
+  .pm-headerControls{ width:100%; flex-direction:column; align-items:stretch; gap:12px; }
+  .pm-headerControls > *{ justify-content:space-between; }
+  .pm-scenarioControl{ width:100%; justify-content:space-between; }
+  .pm-statusGroup{ width:100%; flex-direction:column; align-items:stretch; }
+  .pm-statusGroup .pm-pill{ width:100%; text-align:center; }
+  .pm-runRow{ flex-direction:column; align-items:stretch; }
+  .pm-runRow .pm-mic{ width:100%; justify-content:space-between; }
+  .pm-navRow{ flex-direction:column; align-items:stretch; }
+  .pm-navRow .pm-btn{ width:100%; }
+  .pm-checkRow{ flex-direction:column; align-items:stretch; }
+  .pm-checkRow .pm-btn{ width:100%; }
+  .pm-awaitRow{ flex-direction:column; align-items:stretch; }
+  .pm-awaitRow .pm-btn{ width:100%; }
+  .pm-scoreRow{ flex-direction:column; align-items:flex-start; }
+  .pm-progressRow{ flex-direction:column; align-items:stretch; }
+  .pm-exportRow{ flex-direction:column; align-items:stretch; }
+  .pm-exportRow .pm-btn{ width:100%; }
+  .pm-footer{ flex-direction:column; align-items:flex-start; gap:8px; }
+}
+@media (max-width: 480px){
+  .pm-log{ height:120px }
+  .pm-title img{ height:90px; }
+}


### PR DESCRIPTION
## Summary
- rely solely on automatic responsive mode detection in the trainer UI
- remove the manual view toggle buttons from the trainer header controls
- switch the Piedmont theme to a solid black background on mobile widths instead of the plane image

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca494b886c832b8eb8d9b221835d31