### PR TITLE
Split training experience into desktop and mobile pages

### DIFF
--- a/components/TrainApp.js
+++ b/components/TrainApp.js
@@ -1,4 +1,3 @@
-// pages/train.js
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   unlockAudio,
@@ -21,63 +20,108 @@ function Stepper({ total, current, results = [], onJump }) {
     </div>
   );
 }
+
 function ScoreRing({ pct = 0, size = 72 }) {
   const r = (size - 8) / 2, c = size / 2, circ = 2 * Math.PI * r;
   const off = circ * (1 - pct / 100);
   return (
     <svg className="pm-ring" width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
       <circle cx={c} cy={c} r={r} stroke="#dfeaff" strokeWidth="8" fill="none" />
-      <circle cx={c} cy={c} r={r} stroke="#0e63ff" strokeWidth="8" fill="none"
-              strokeDasharray={circ} strokeDashoffset={off} strokeLinecap="round" />
+      <circle
+        cx={c}
+        cy={c}
+        r={r}
+        stroke="#0e63ff"
+        strokeWidth="8"
+        fill="none"
+        strokeDasharray={circ}
+        strokeDashoffset={off}
+        strokeLinecap="round"
+      />
       <text x="50%" y="54%" textAnchor="middle" fontSize="14" fill="#0b1e39">{pct}%</text>
     </svg>
   );
 }
+
 function WordDiff({ expected = "", heard = "" }) {
   const A = expected.trim().split(/\s+/);
   const B = new Set(heard.trim().toLowerCase().split(/\s+/));
   return (
     <p className="pm-diff">
-      {A.map((w, i) => <span key={i} className={B.has(w.toLowerCase()) ? "pm-wok" : "pm-wmiss"}>{w} </span>)}
+      {A.map((w, i) => (
+        <span key={i} className={B.has(w.toLowerCase()) ? "pm-wok" : "pm-wmiss"}>
+          {w}{" "}
+        </span>
+      ))}
     </p>
   );
 }
+
 function MicWidget({ status = "idle", level = 0 }) {
   return (
     <div className="pm-mic">
       <span className="pm-pill">Mic: {status}</span>
-      <div className="pm-meter"><div className="pm-fill" style={{ width: `${Math.min(100, level)}%` }} /></div>
+      <div className="pm-meter">
+        <div className="pm-fill" style={{ width: `${Math.min(100, level)}%` }} />
+      </div>
     </div>
   );
 }
+
 const _toasts = [];
 function toast(msg, kind = "info", ms = 2200) {
-  _toasts.push({ id: Date.now(), msg, kind }); renderToasts();
-  setTimeout(() => { _toasts.shift(); renderToasts(); }, ms);
+  _toasts.push({ id: Date.now(), msg, kind });
+  renderToasts();
+  setTimeout(() => {
+    _toasts.shift();
+    renderToasts();
+  }, ms);
 }
+
 function renderToasts() {
   let host = document.getElementById("pm-toast-host");
-  if (!host) { host = document.createElement("div"); host.id = "pm-toast-host"; host.className = "pm-toasts"; document.body.appendChild(host); }
-  host.innerHTML = _toasts.map(t => `<div class="pm-toast ${t.kind}">${t.msg}</div>`).join("");
+  if (!host) {
+    host = document.createElement("div");
+    host.id = "pm-toast-host";
+    host.className = "pm-toasts";
+    document.body.appendChild(host);
+  }
+  host.innerHTML = _toasts.map((t) => `<div class="pm-toast ${t.kind}">${t.msg}</div>`).join("");
 }
-function useResponsiveMode() {
+
+function useResponsiveMode(forcedMode) {
   const pick = () => (window.innerWidth <= 860 ? "mobile" : "desktop");
-  const [mode, setMode] = useState(() => (typeof window === "undefined" ? "desktop" : pick()));
+  const [mode, setMode] = useState(() => {
+    if (forcedMode) return forcedMode;
+    return typeof window === "undefined" ? "desktop" : pick();
+  });
+
   useEffect(() => {
+    if (forcedMode) return;
     const onResize = () => setMode(pick());
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, []);
+  }, [forcedMode]);
+
+  useEffect(() => {
+    if (forcedMode) setMode(forcedMode);
+  }, [forcedMode]);
+
   return mode;
 }
+
 function downloadCSV(rows, filename = "deice-results.csv") {
-  const csv = rows.map(r => r.map(v => `"${String(v ?? "").replace(/"/g, '""')}"`).join(",")).join("\n");
+  const csv = rows.map((r) => r.map((v) => `"${String(v ?? "").replace(/"/g, '""')}"`).join(",")).join("\n");
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob); const a = document.createElement("a");
-  a.href = url; a.download = filename; a.click(); URL.revokeObjectURL(url);
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
 }
 
-export default function TrainPage() {
+function TrainApp({ forcedMode }) {
   // scenario list + current
   const [scenarioList, setScenarioList] = useState([]);
   const [current, setCurrent] = useState(null);
@@ -99,7 +143,7 @@ export default function TrainPage() {
   const [awaitingAdvance, setAwaitingAdvance] = useState(false);
   const [resultsVersion, setResultsVersion] = useState(0);
 
-  const mode = useResponsiveMode();
+  const mode = useResponsiveMode(forcedMode);
 
   const runningRef = useRef(false);
   const pausedRef = useRef(false);
@@ -117,9 +161,11 @@ export default function TrainPage() {
       resolvePrompt();
     }
   }, [autoAdvance]);
-  useEffect(() => { awaitingAdvanceRef.current = awaitingAdvance; }, [awaitingAdvance]);
+  useEffect(() => {
+    awaitingAdvanceRef.current = awaitingAdvance;
+  }, [awaitingAdvance]);
 
-  const gradedTotal = useMemo(() => (steps || []).filter(s => s.role === "Iceman").length, [steps]);
+  const gradedTotal = useMemo(() => (steps || []).filter((s) => s.role === "Iceman").length, [steps]);
   const correct = useMemo(() => {
     return (resultsRef.current || []).reduce((acc, val, idx) => {
       return acc + (steps[idx]?.role === "Iceman" && val === true ? 1 : 0);
@@ -130,7 +176,7 @@ export default function TrainPage() {
   const micLevel = micLevelRef.current || 0;
   const activeSpeechLabelId = autoAdvance ? "speech-mode-auto" : "speech-mode-manual";
 
-  const log = (msg) => setLogText(t => (t ? t + "\n" : "") + msg);
+  const log = (msg) => setLogText((t) => (t ? t + "\n" : "") + msg);
 
   // 1) Load scenario list for dropdown
   useEffect(() => {
@@ -147,7 +193,7 @@ export default function TrainPage() {
           const data = await res2.json();
           setCurrent(data);
           resultsRef.current = Array(data.steps.length).fill(undefined);
-          setResultsVersion(v => v + 1);
+          setResultsVersion((v) => v + 1);
           setStatus("Scenario loaded");
           setStepIndex(-1);
           setAnswer("");
@@ -163,7 +209,9 @@ export default function TrainPage() {
         console.error("Load scenario list failed", e);
       }
     })();
-    return () => { live = false; };
+    return () => {
+      live = false;
+    };
   }, []);
 
   // 2) subscribe to captain audio status
@@ -180,18 +228,20 @@ export default function TrainPage() {
     return () => clearInterval(id);
   }, []);
 
-  function normalize(s){ return s.toLowerCase().replace(/[^a-z0-9 ]/g,"").replace(/\s+/g," ").trim(); }
+  function normalize(s) {
+    return s.toLowerCase().replace(/[^a-z0-9 ]/g, "").replace(/\s+/g, " ").trim();
+  }
   function quickScore(expected, heard) {
     const A = new Set(normalize(expected).split(" "));
     const B = new Set(normalize(heard).split(" "));
-    const inter = [...A].filter(x => B.has(x)).length;
+    const inter = [...A].filter((x) => B.has(x)).length;
     return A.size ? Math.round((inter / A.size) * 100) : 0;
   }
 
   function preloadCaptainForScenario(scn) {
     const scnId = scn?.id;
     if (!scnId) return;
-    const cues = Array.from(new Set((scn.steps || []).filter(s => s.role === "Captain" && s.cue).map(s => s.cue)));
+    const cues = Array.from(new Set((scn.steps || []).filter((s) => s.role === "Captain" && s.cue).map((s) => s.cue)));
     preloadCaptainCues(scnId, cues);
   }
 
@@ -212,7 +262,7 @@ export default function TrainPage() {
         log("Mic permission granted by getUserMedia().");
       }
 
-      const cues = (current?.steps || []).filter(s => s.role === "Captain" && s.cue).map(s => s.cue);
+      const cues = (current?.steps || []).filter((s) => s.role === "Captain" && s.cue).map((s) => s.cue);
       if (cues.length) {
         preloadCaptainCues(current?.id || "default", cues);
         log(`Preloaded Captain cues: ${cues.join(", ")}`);
@@ -231,47 +281,44 @@ export default function TrainPage() {
     }
   }
 
+  async function onStart() {
+    try {
+      const ok = await prepareMic();
+      if (!ok) return;
 
-async function onStart() {
-  try {
-    const ok = await prepareMic();
-    if (!ok) return;
+      pausedRef.current = false;
+      runningRef.current = true;
+      setStatus(preparedRef.current ? "Running…" : "Running (no mic)");
+      log("Simulation started.");
 
-    pausedRef.current = false;
-    runningRef.current = true;
-    setStatus(preparedRef.current ? "Running…" : "Running (no mic)");
-    log("Simulation started.");
+      // First start: move to step 0 if needed
+      if (stepIndex < 0 && steps.length) {
+        setStepIndex(0);
+      }
 
-    // First start: move to step 0 if needed
-    if (stepIndex < 0 && steps.length) {
-      setStepIndex(0);
+      runSimulator();
+    } catch (e) {
+      console.error("Start failed:", e);
+      setStatus("Start failed");
+      toast("Start failed", "error");
     }
-
-    runSimulator();
-  } catch (e) {
-    console.error("Start failed:", e);
-    setStatus("Start failed");
-    toast("Start failed", "error");
   }
-}
 
-
-// Pause simulator and all audio cleanly
-function onPause() {
-  try {
-    pausedRef.current = true;
-    runningRef.current = false;
-    stopAudio();
-    resolvePrompt({ silent: true });
-    setStatus("Paused");
-    log("Simulation paused.");
-    toast("Paused", "info");
-  } catch (e) {
-    console.error("Pause failed:", e);
-    toast("Pause failed", "error");
+  // Pause simulator and all audio cleanly
+  function onPause() {
+    try {
+      pausedRef.current = true;
+      runningRef.current = false;
+      stopAudio();
+      resolvePrompt({ silent: true });
+      setStatus("Paused");
+      log("Simulation paused.");
+      toast("Paused", "info");
+    } catch (e) {
+      console.error("Pause failed:", e);
+      toast("Pause failed", "error");
+    }
   }
-}
-
 
   function onCheck() {
     if (stepIndex < 0 || !steps[stepIndex]) return;
@@ -279,9 +326,9 @@ function onPause() {
     const p = quickScore(exp, answer);
     const ok = p >= 60;
     resultsRef.current[stepIndex] = ok;
-    setResultsVersion(v => v + 1);
+    setResultsVersion((v) => v + 1);
     setLastResultText(ok ? `✅ Good (${p}%)` : `❌ Try again (${p}%)`);
-    if (!ok) setRetryCount(n => n + 1);
+    if (!ok) setRetryCount((n) => n + 1);
     log(`[Step ${stepIndex + 1}] Score ${p}% → ${ok ? "OK" : "MISS"}`);
   }
 
@@ -290,7 +337,7 @@ function onPause() {
       ["Scenario", current?.label || ""],
       [],
       ["Step", "Role", "Expected", "Result"],
-      ...steps.map((s, i) => [i + 1, s.role, s.text, resultsRef.current[i] ? "OK" : "MISS"])
+      ...steps.map((s, i) => [i + 1, s.role, s.text, resultsRef.current[i] ? "OK" : "MISS"]),
     ];
     downloadCSV(rows, `deice_${current?.id || "scenario"}.csv`);
     toast("CSV downloaded", "success");
@@ -309,7 +356,10 @@ function onPause() {
   }
 
   async function runSimulator() {
-    if (!current || !steps.length) { setStatus("Select a scenario first."); return; }
+    if (!current || !steps.length) {
+      setStatus("Select a scenario first.");
+      return;
+    }
 
     const runId = Date.now();
     runIdRef.current = runId;
@@ -336,7 +386,7 @@ function onPause() {
         }
         if (resultsRef.current[idx] !== true) {
           resultsRef.current[idx] = true;
-          setResultsVersion(v => v + 1);
+          setResultsVersion((v) => v + 1);
         }
       } else if (step.role === "Iceman") {
         setAnswer("");
@@ -380,10 +430,10 @@ function onPause() {
         const score = quickScore(expected, heard);
         const ok = score >= 60;
         resultsRef.current[idx] = ok;
-        setResultsVersion(v => v + 1);
+        setResultsVersion((v) => v + 1);
         setLastResultText(ok ? `✅ Good (${score}%)` : `❌ Try again (${score}%)`);
         if (!ok) {
-          setRetryCount(n => n + 1);
+          setRetryCount((n) => n + 1);
           toast("Let's try that line again.", "info");
         }
         log(`[Step ${idx + 1}] Auto score ${score}% → ${ok ? "OK" : "MISS"}`);
@@ -393,7 +443,9 @@ function onPause() {
           awaitingAdvanceRef.current = true;
           setAwaitingAdvance(true);
           log("Awaiting confirmation to proceed.");
-          await new Promise(resolve => { proceedResolverRef.current = resolve; });
+          await new Promise((resolve) => {
+            proceedResolverRef.current = resolve;
+          });
           proceedResolverRef.current = null;
           awaitingAdvanceRef.current = false;
           setAwaitingAdvance(false);
@@ -403,7 +455,7 @@ function onPause() {
       } else {
         if (resultsRef.current[idx] === undefined) {
           resultsRef.current[idx] = true;
-          setResultsVersion(v => v + 1);
+          setResultsVersion((v) => v + 1);
         }
       }
 
@@ -425,7 +477,6 @@ function onPause() {
       toast("Session complete", finalPct >= 80 ? "success" : "info");
     }
   }
-
 
   return (
     <div className="pm-app">
@@ -449,7 +500,7 @@ function onPause() {
                   const scn = await res.json();
                   setCurrent(scn);
                   resultsRef.current = Array(scn.steps.length).fill(undefined);
-                  setResultsVersion(v => v + 1);
+                  setResultsVersion((v) => v + 1);
                   setStepIndex(-1);
                   setStatus("Scenario loaded");
                   log(`Scenario loaded: ${scn.label}`);
@@ -463,7 +514,11 @@ function onPause() {
                   preloadCaptainForScenario(scn);
                 }}
               >
-                {(scenarioList || []).map(s => <option key={s.id} value={s.id}>{s.label}</option>)}
+                {(scenarioList || []).map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.label}
+                  </option>
+                ))}
               </select>
             </div>
             <div className="pm-statusGroup">
@@ -479,14 +534,17 @@ function onPause() {
           <section className="pm-panel">
             <div className="pm-runRow">
               <div className="pm-row pm-startControls">
-                <button type="button" className="pm-btn" onClick={onStart}>Start</button>
-                <button type="button" className="pm-btn ghost" onClick={onPause}>Pause</button>
+                <button type="button" className="pm-btn" onClick={onStart}>
+                  Start
+                </button>
+                <button type="button" className="pm-btn ghost" onClick={onPause}>
+                  Pause
+                </button>
                 <div className="pm-row pm-speechToggle">
-                  <span className="pm-label" id="speech-mode-label">Speech mode</span>
-                  <span
-                    id="speech-mode-auto"
-                    className={`pm-switchOption${autoAdvance ? " active" : ""}`}
-                  >
+                  <span className="pm-label" id="speech-mode-label">
+                    Speech mode
+                  </span>
+                  <span id="speech-mode-auto" className={`pm-switchOption${autoAdvance ? " active" : ""}`}>
                     Auto
                   </span>
                   <button
@@ -505,10 +563,7 @@ function onPause() {
                       <span className="pm-switchThumb" />
                     </span>
                   </button>
-                  <span
-                    id="speech-mode-manual"
-                    className={`pm-switchOption${autoAdvance ? "" : " active"}`}
-                  >
+                  <span id="speech-mode-manual" className={`pm-switchOption${autoAdvance ? "" : " active"}`}>
                     Manual
                   </span>
                 </div>
@@ -519,44 +574,73 @@ function onPause() {
             <div style={{ marginTop: 10 }}>
               <div className="pm-label">Current Line</div>
               <div className="pm-coach">
-                {stepIndex >= 0 && steps[stepIndex]
-                  ? (<><strong>{steps[stepIndex].role}:</strong> {steps[stepIndex].text}</>)
-                  : "Select a step and press Start."}
+                {stepIndex >= 0 && steps[stepIndex] ? (
+                  <>
+                    <strong>{steps[stepIndex].role}:</strong> {steps[stepIndex].text}
+                  </>
+                ) : (
+                  "Select a step and press Start."
+                )}
               </div>
             </div>
 
             <div className="pm-row pm-navRow" style={{ marginTop: 8 }}>
-              <button className="pm-btn" onClick={() => {
-                resolvePrompt({ silent: true });
-                setStepIndex(i => {
-                  const n = Math.max(0, (typeof i === "number" ? i : 0) - 1);
-                  const s = steps[n]; if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
-                  return n;
-                });
-              }}>⟵ Prev</button>
-              <button className="pm-btn primary" onClick={() =>
-                {
+              <button
+                className="pm-btn"
+                onClick={() => {
+                  resolvePrompt({ silent: true });
+                  setStepIndex((i) => {
+                    const n = Math.max(0, (typeof i === "number" ? i : 0) - 1);
+                    const s = steps[n];
+                    if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
+                    return n;
+                  });
+                }}
+              >
+                ⟵ Prev
+              </button>
+              <button
+                className="pm-btn primary"
+                onClick={() => {
                   if (awaitingAdvanceRef.current) {
                     log("Advance confirmed via Next button.");
                     resolvePrompt();
                     return;
                   }
-                  setStepIndex(i => {
+                  setStepIndex((i) => {
                     const n = Math.min(total - 1, (typeof i === "number" ? i : -1) + 1);
-                    const s = steps[n]; if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
+                    const s = steps[n];
+                    if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
                     return n;
                   });
-                }}>Next ⟶</button>
-              <button className="pm-btn" onClick={() => {
-                const s = steps[stepIndex]; if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
-              }}>▶︎ Play line</button>
+                }}
+              >
+                Next ⟶
+              </button>
+              <button
+                className="pm-btn"
+                onClick={() => {
+                  const s = steps[stepIndex];
+                  if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
+                }}
+              >
+                ▶︎ Play line
+              </button>
             </div>
 
             <div style={{ marginTop: 10 }}>
               <div className="pm-label">Your Response</div>
-              <textarea rows={3} className="pm-input" value={answer} onChange={e => setAnswer(e.target.value)} placeholder="Speak or type your line…" />
+              <textarea
+                rows={3}
+                className="pm-input"
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                placeholder="Speak or type your line…"
+              />
               <div className="pm-row pm-checkRow" style={{ marginTop: 6 }}>
-                <button className="pm-btn" onClick={onCheck}>Check</button>
+                <button className="pm-btn" onClick={onCheck}>
+                  Check
+                </button>
                 <span className="pm-pill">{lastResultText}</span>
               </div>
             </div>
@@ -584,20 +668,30 @@ function onPause() {
             <div className="pm-row pm-progressRow">
               <div>
                 <div className="pm-label">Progress</div>
-                <Stepper total={total} current={Math.max(0, stepIndex)} results={resultsRef.current || []}
-                         onJump={(i) => {
-                           resolvePrompt({ silent: true });
-                           setStepIndex(i);
-                           const s = steps[i];
-                           if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
-                         }} />
+                <Stepper
+                  total={total}
+                  current={Math.max(0, stepIndex)}
+                  results={resultsRef.current || []}
+                  onJump={(i) => {
+                    resolvePrompt({ silent: true });
+                    setStepIndex(i);
+                    const s = steps[i];
+                    if (s?.role === "Captain" && s.cue && current?.id) playCaptainCue(current.id, s.cue);
+                  }}
+                />
               </div>
               <div className="pm-scoreRow">
                 <ScoreRing pct={pct} />
                 <div>
-                  <div className="pm-pill">Correct: <strong>{correct}/{gradedTotal}</strong></div>
-                  <div className="pm-pill">Retries: <strong>{retryCount || 0}</strong></div>
-                  <div className="pm-pill">Avg. Response: <strong>{avgRespSec?.toFixed?.(1) ?? "—"}s</strong></div>
+                  <div className="pm-pill">
+                    Correct: <strong>{correct}/{gradedTotal}</strong>
+                  </div>
+                  <div className="pm-pill">
+                    Retries: <strong>{retryCount || 0}</strong>
+                  </div>
+                  <div className="pm-pill">
+                    Avg. Response: <strong>{avgRespSec?.toFixed?.(1) ?? "—"}s</strong>
+                  </div>
                 </div>
               </div>
             </div>
@@ -608,8 +702,12 @@ function onPause() {
             </div>
 
             <div className="pm-row pm-exportRow" style={{ marginTop: 10 }}>
-              <button className="pm-btn ghost" onClick={exportSession}>Export CSV</button>
-              <button className="pm-btn ghost" onClick={() => toast("Saved settings","success")}>Save Settings</button>
+              <button className="pm-btn ghost" onClick={exportSession}>
+                Export CSV
+              </button>
+              <button className="pm-btn ghost" onClick={() => toast("Saved settings", "success")}>
+                Save Settings
+              </button>
             </div>
           </section>
         </div>
@@ -623,3 +721,13 @@ function onPause() {
     </div>
   );
 }
+
+export function DesktopTrainApp() {
+  return <TrainApp forcedMode="desktop" />;
+}
+
+export function MobileTrainApp() {
+  return <TrainApp forcedMode="mobile" />;
+}
+
+export default TrainApp;

--- a/pages/desktop_train.js
+++ b/pages/desktop_train.js
@@ -1,0 +1,5 @@
+import { DesktopTrainApp } from "../components/TrainApp";
+
+export default function DesktopTrainPage() {
+  return <DesktopTrainApp />;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,14 @@
 export default function Home() {
   return (
     <div className="wrap">
-      <div className="row" style={{justifyContent:'space-between'}}>
-        <div className="btn ghost" as="a" href="/train">Open Trainer →</div>
+      <div className="row" style={{ justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' }}>
+        <a className="btn ghost" href="/desktop_train">Desktop Version →</a>
+        <a className="btn ghost" href="/mobile_train">Mobile Version →</a>
       </div>
 
       <div className="card">
-        <h1 style={{margin:'0 0 6px'}}>De-Ice Trainer</h1>
-        <p className="status" style={{margin:0}}>
+        <h1 style={{ margin: '0 0 6px' }}>De-Ice Trainer</h1>
+        <p className="status" style={{ margin: 0 }}>
           Practice agent-to-flight deck de-ice/anti-ice communications by voice.
           Optimized for iOS Safari (mic) and Chrome.
         </p>
@@ -16,7 +17,7 @@ export default function Home() {
       <div className="card">
         <h2>Train</h2>
         <p>Captain lines play; you speak Iceman. Live transcript, highlights, and scoring.</p>
-        <a className="btn" href="/train">Start Training</a>
+        <a className="btn" href="/desktop_train">Start Training</a>
       </div>
 
       <div className="status">V2 • For training purposes only • OMA Station • 2025</div>

--- a/pages/mobile_train.js
+++ b/pages/mobile_train.js
@@ -1,0 +1,5 @@
+import { MobileTrainApp } from "../components/TrainApp";
+
+export default function MobileTrainPage() {
+  return <MobileTrainApp />;
+}


### PR DESCRIPTION
## Summary
- move the training experience into a shared component that supports forcing desktop or mobile layouts
- add new /desktop_train and /mobile_train pages that render the shared component in their respective modes
- update the home page CTA buttons to link to the new desktop and mobile routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad3de85d4832b879648525d370875