### PR TITLE
Show percentage value on score ring

### DIFF
--- a/components/TrainApp.js
+++ b/components/TrainApp.js
@@ -667,7 +667,7 @@ function TrainApp({ forcedMode }) {
         />
       </div>
       <div className={`pm-scoreRow${isMobile ? " pm-scoreRowCompact" : ""}`}>
-        {!isMobile && <ScoreRing pct={pct} label={totalScore} />}
+        {!isMobile && <ScoreRing pct={pct} />}
         {scoreDetails}
       </div>
     </div>
@@ -685,10 +685,10 @@ function TrainApp({ forcedMode }) {
     </div>
   );
 
-  const totalScoreText = totalPossible ? `${totalScore} of ${totalPossible}` : `${totalScore}`;
+  const totalScoreText = totalPossible ? `${pct}% (${totalScore} of ${totalPossible})` : `${pct}%`;
   const scoreBlock = (
     <div className="pm-headerScore" aria-label={`Iceman total ${totalScoreText}`}>
-      <ScoreRing pct={pct} size={isMobile ? mobileScoreSize : 60} label={totalScore} />
+      <ScoreRing pct={pct} size={isMobile ? mobileScoreSize : 60} />
     </div>
   );
 


### PR DESCRIPTION
## Summary
- display the score ring label as the calculated percentage so users see a 0-100% result
- include the percentage in the aria-label while retaining the detailed score totals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb8605856c832bb7f75479beffd520