### PR TITLE
Shrink header status pills

### DIFF
--- a/components/TrainApp.js
+++ b/components/TrainApp.js
@@ -794,8 +794,8 @@ function TrainApp({ forcedMode }) {
 
   const statusBlock = (
     <div className={`pm-statusGroup${isMobile ? " pm-statusGroupCompact" : ""}`}>
-      <span className={`pm-pill${isMobile ? " pm-pillCompact" : ""}`}>{status}</span>
-      <span className={`pm-pill${isMobile ? " pm-pillCompact" : ""}`}>Captain: {captainStatus}</span>
+      <span className="pm-pill pm-pillCompact">{status}</span>
+      <span className="pm-pill pm-pillCompact">Captain: {captainStatus}</span>
     </div>
   );
 


### PR DESCRIPTION
## Summary
- apply the compact pill styling to the header status indicators so they match the mic chip size

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb9ac40730832ba3de3122f678c20c