### PR TITLE
Add employee-number login and stats saving API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+data/

--- a/pages/api/logs-write.js
+++ b/pages/api/logs-write.js
@@ -1,4 +1,44 @@
+import path from "path";
+import { promises as fs } from "fs";
+
+const LOG_DIR = path.join(process.cwd(), "data");
+const LOG_FILE = path.join(LOG_DIR, "stats.jsonl");
+const EMPLOYEE_ID_REGEX = /^\d{4,10}$/;
+
 export default async function handler(req, res) {
-  // Wire to Supabase later; this prevents 404s while you iterate
-  res.status(501).json({ error: 'Not implemented' });
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  try {
+    const body = req.body || {};
+    const { employeeId, scenarioId, scenarioLabel, recordedAt, summary, steps } = body;
+
+    if (typeof employeeId !== "string" || !EMPLOYEE_ID_REGEX.test(employeeId)) {
+      res.status(400).json({ error: "Invalid employeeId" });
+      return;
+    }
+
+    const safeSummary = summary && typeof summary === "object" ? summary : {};
+    const safeSteps = Array.isArray(steps) ? steps : [];
+
+    const entry = {
+      employeeId,
+      scenarioId: typeof scenarioId === "string" ? scenarioId : safeSummary.scenarioId || "",
+      scenarioLabel: typeof scenarioLabel === "string" ? scenarioLabel : safeSummary.scenarioLabel || "",
+      recordedAt: typeof recordedAt === "string" ? recordedAt : new Date().toISOString(),
+      summary: safeSummary,
+      steps: safeSteps,
+    };
+
+    await fs.mkdir(LOG_DIR, { recursive: true });
+    await fs.appendFile(LOG_FILE, JSON.stringify(entry) + "\n", "utf8");
+
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error("Failed to save stats", err);
+    res.status(500).json({ error: "Failed to save stats" });
+  }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -155,6 +155,58 @@ body.piedmont {
 .pm-navRow, .pm-checkRow, .pm-awaitRow { gap:8px; align-items:center; flex-wrap:wrap; }
 .pm-progressRow { justify-content:space-between; align-items:flex-start; gap:12px; flex-wrap:wrap; }
 .pm-exportRow { justify-content:flex-end; gap:10px; flex-wrap:wrap; }
+.pm-employeeRow { justify-content:flex-start; gap:8px; flex-wrap:wrap; }
+.pm-employeeRow .pm-pill { flex:1 1 auto; min-width:0; }
+
+.pm-modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 22, 46, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 1000;
+}
+
+.pm-modal {
+  background: #ffffff;
+  color: var(--ink);
+  border-radius: 16px;
+  box-shadow: 0 18px 48px rgba(5, 30, 74, 0.22);
+  padding: 20px;
+  max-width: 420px;
+  width: min(420px, 100%);
+}
+
+.pm-modal h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.pm-modal p {
+  margin: 0 0 14px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.pm-fieldLabel { display:block; margin-bottom:6px; }
+.pm-fieldError { color: var(--err); font-size: 12px; margin-top: 6px; }
+
+.pm-modalActions {
+  margin-top: 16px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.pm-modalActions .pm-btn { flex: 0 0 auto; }
+
+.pm-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 
 /* panels */
 .pm-panel { background: #e2e8f0; border: 1px solid var(--border); border-radius: 12px; padding: 12px; }


### PR DESCRIPTION
## Summary
- add an employee ID login workflow with persisted storage and modal prompts in the trainer UI
- wire the Save Stats action to post detailed session results to a new API route writing JSONL records
- add styling for the login modal and ignore generated data output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb9d3d98c0832b9dc80e34dfbfa535