### PR TITLE
Add speech synthesis fallback for captain audio

### DIFF
--- a/lib/audio.js
+++ b/lib/audio.js
@@ -2,6 +2,7 @@
 
 const exts = ["mp3", "m4a"];
 const ROOT = "/audio"; // served from /public/audio
+const SPEECH_TIMEOUT_MS = 15000;
 
 // Mini event bus so UI can show audio status
 const bus = new EventTarget();
@@ -21,6 +22,70 @@ function getEl() {
     el.setAttribute("playsinline", "true");
   }
   return el;
+}
+
+function canUseSpeechSynthesis() {
+  if (typeof window === "undefined") return false;
+  return Boolean(window.speechSynthesis && window.SpeechSynthesisUtterance);
+}
+
+async function speakText(label, text) {
+  const line = String(text || "").trim();
+  if (!line || !canUseSpeechSynthesis()) return false;
+
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (ok) => {
+      if (finished) return;
+      finished = true;
+      resolve(ok);
+    };
+
+    try {
+      const synth = window.speechSynthesis;
+      if (!synth) {
+        finish(false);
+        return;
+      }
+
+      emit("status", { who: label, status: "loading", mode: "synth" });
+
+      const utterance = new window.SpeechSynthesisUtterance(line);
+      utterance.lang = "en-US";
+      utterance.rate = 1;
+      utterance.pitch = 1;
+      let guard = null;
+      utterance.onstart = () => emit("status", { who: label, status: "playing", src: "synth" });
+      utterance.onend = () => {
+        if (guard) clearTimeout(guard);
+        emit("status", { who: label, status: "ended" });
+        finish(true);
+      };
+      utterance.onerror = (event) => {
+        if (guard) clearTimeout(guard);
+        console.error(`[audio] speech synthesis failed for ${label}`, event);
+        emit("status", { who: label, status: "error" });
+        finish(false);
+      };
+
+      try {
+        synth.cancel();
+      } catch (err) {
+        console.warn("[audio] speech synthesis cancel failed", err);
+      }
+
+      synth.speak(utterance);
+
+      guard = setTimeout(() => {
+        emit("status", { who: label, status: "ended" });
+        finish(true);
+      }, Math.min(SPEECH_TIMEOUT_MS, Math.max(4000, line.length * 80)));
+    } catch (err) {
+      console.error(`[audio] speech synthesis crashed for ${label}`, err);
+      emit("status", { who: label, status: "error" });
+      finish(false);
+    }
+  });
 }
 
 // iOS/Safari unlock: call after a user gesture (Prepare Mic)
@@ -94,9 +159,21 @@ async function playFromCandidates(label, candidates) {
 }
 
 // Public API
-export async function playCaptainCue(scnId, cue) {
+export async function playCaptainCue(scnId, cue, fallbackText = "") {
   const candidates = exts.map(ext => captainSrc(scnId, cue, ext));
-  return playFromCandidates("captain", candidates);
+  const ok = await playFromCandidates("captain", candidates);
+  if (ok) return true;
+
+  const fallbackLine = typeof fallbackText === "string" ? fallbackText.trim() : "";
+  if (!fallbackLine) return false;
+
+  const synthOk = await speakText("captain", fallbackLine);
+  if (synthOk) {
+    console.warn(`[audio] using speech synthesis fallback for ${cue}`);
+    return true;
+  }
+
+  return false;
 }
 
 export function preloadCaptainCues(scnId, cues = []) {

--- a/lib/audio.js
+++ b/lib/audio.js
@@ -14,6 +14,8 @@ function emit(type, detail) { bus.dispatchEvent(new CustomEvent(type, { detail }
 
 // Shared <audio> element
 let el;
+const ttsCache = new Map();
+const OPENAI_TTS_PATH = "/api/openai-tts";
 function getEl() {
   if (!el) {
     el = new Audio();
@@ -85,6 +87,119 @@ async function speakText(label, text) {
       emit("status", { who: label, status: "error" });
       finish(false);
     }
+  });
+}
+
+async function fetchOpenAITTS(key, text, meta = {}) {
+  if (typeof window === "undefined") return null;
+  if (!text) return null;
+
+  const trimmed = String(text || "").trim();
+  if (!trimmed) return null;
+
+  if (ttsCache.has(key)) {
+    return ttsCache.get(key);
+  }
+
+  const job = (async () => {
+    try {
+      const payload = { text: trimmed };
+      if (meta.cue) payload.cue = meta.cue;
+      if (meta.scenario) payload.scenario = meta.scenario;
+      const res = await fetch(OPENAI_TTS_PATH, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        let detail = "";
+        try {
+          detail = await res.text();
+        } catch (_) {
+          /* ignore */
+        }
+        throw new Error(`status ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`);
+      }
+
+      const buffer = await res.arrayBuffer();
+      const type = res.headers.get("content-type") || "audio/mpeg";
+      return new Blob([buffer], { type });
+    } catch (err) {
+      console.error(`[audio] OpenAI TTS fetch failed for ${key}`, err);
+      return null;
+    }
+  })();
+
+  ttsCache.set(key, job);
+
+  const blob = await job;
+  if (!blob) {
+    ttsCache.delete(key);
+  }
+  return blob;
+}
+
+async function playBlobAudio(label, blob, { mode = "blob", source = "", skipInitialEmit = false } = {}) {
+  if (!blob) return false;
+
+  const a = getEl();
+  const url = URL.createObjectURL(blob);
+  a.onended = a.onerror = a.oncanplay = a.onloadedmetadata = null;
+
+  const emitStatus = (status) => emit("status", { who: label, status, src: source || "blob", mode });
+  if (!skipInitialEmit) emitStatus("loading");
+
+  a.src = url;
+  try { a.load(); } catch (_) {}
+  a.muted = false; a.volume = 1;
+
+  return new Promise((resolve) => {
+    let finished = false;
+    let guard = null;
+
+    const cleanup = () => {
+      if (guard) clearTimeout(guard);
+      a.onended = a.onerror = a.oncanplay = a.onloadedmetadata = null;
+      URL.revokeObjectURL(url);
+    };
+
+    const finish = (ok) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      resolve(ok);
+    };
+
+    a.onloadedmetadata = () => {
+      const ms = isFinite(a.duration) && a.duration > 0 ? Math.min(15000, a.duration * 1000 + 1000) : 12000;
+      guard = setTimeout(() => {
+        emitStatus("ended");
+        finish(true);
+      }, ms);
+    };
+
+    a.oncanplay = async () => {
+      try {
+        await a.play();
+        emitStatus("playing");
+      } catch (err) {
+        console.error(`[audio] play() failed for ${source || "blob"}`, err);
+        emitStatus("error");
+        finish(false);
+      }
+    };
+
+    a.onended = () => {
+      emitStatus("ended");
+      finish(true);
+    };
+
+    a.onerror = (event) => {
+      console.error(`[audio] error while playing blob for ${label}`, event);
+      emitStatus("error");
+      finish(false);
+    };
   });
 }
 
@@ -166,6 +281,23 @@ export async function playCaptainCue(scnId, cue, fallbackText = "") {
 
   const fallbackLine = typeof fallbackText === "string" ? fallbackText.trim() : "";
   if (!fallbackLine) return false;
+
+  const ttsKey = `${scnId || "scenario"}::${cue || fallbackLine.slice(0, 32)}`;
+  emit("status", { who: "captain", status: "loading", mode: "openai" });
+  const ttsBlob = await fetchOpenAITTS(ttsKey, fallbackLine, { cue, scenario: scnId });
+  if (ttsBlob) {
+    const playedTts = await playBlobAudio("captain", ttsBlob, {
+      mode: "openai",
+      source: "openai-tts",
+      skipInitialEmit: true,
+    });
+    if (playedTts) {
+      console.warn(`[audio] using OpenAI TTS fallback for ${cue || "captain line"}`);
+      return true;
+    }
+  } else {
+    emit("status", { who: "captain", status: "error", mode: "openai" });
+  }
 
   const synthOk = await speakText("captain", fallbackLine);
   if (synthOk) {

--- a/pages/api/openai-tts.js
+++ b/pages/api/openai-tts.js
@@ -1,0 +1,86 @@
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "2mb",
+    },
+  },
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: "OpenAI API key not configured" });
+    return;
+  }
+
+  const { text, voice, format, cue, scenario } = req.body || {};
+  const input = typeof text === "string" ? text.trim() : "";
+  if (!input) {
+    res.status(400).json({ error: "Missing text" });
+    return;
+  }
+  if (input.length > 800) {
+    res.status(400).json({ error: "Text too long" });
+    return;
+  }
+
+  const model = process.env.OPENAI_TTS_MODEL || "gpt-4o-mini-tts";
+  const voiceChoice = (typeof voice === "string" && voice.trim()) || process.env.OPENAI_TTS_VOICE || "alloy";
+  const outputFormat = (typeof format === "string" && format.trim()) || "mp3";
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/audio/speech", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        voice: voiceChoice,
+        input,
+        format: outputFormat,
+      }),
+    });
+
+    if (!response.ok) {
+      let detail = "";
+      try {
+        detail = await response.text();
+      } catch (err) {
+        detail = "";
+      }
+      console.error("[api/openai-tts] OpenAI request failed", {
+        status: response.status,
+        cue,
+        scenario,
+        detail: detail ? detail.slice(0, 500) : undefined,
+      });
+      res.status(response.status).json({
+        error: "OpenAI TTS request failed",
+        detail: detail ? detail.slice(0, 200) : undefined,
+      });
+      return;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const contentType = response.headers.get("content-type") || (outputFormat === "wav" ? "audio/wav" : "audio/mpeg");
+
+    res.setHeader("Content-Type", contentType);
+    res.setHeader("Cache-Control", "no-store");
+    if (cue) {
+      res.setHeader("X-Captain-Cue", String(cue));
+    }
+    res.status(200).send(buffer);
+  } catch (err) {
+    console.error("[api/openai-tts] Unexpected error", { cue, scenario, err });
+    res.status(500).json({ error: "Failed to generate speech audio" });
+  }
+}


### PR DESCRIPTION
## Summary
- add a speech-synthesis fallback in the audio helper so captain lines can still play when media files fail
- update the training UI to log/toast captain audio issues and pass the script text into the fallback across navigation controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce6add728c832b978d0c8676a2efcb