### PR TITLE
Fix captain audio playback volume handling

### DIFF
--- a/lib/audio.js
+++ b/lib/audio.js
@@ -13,6 +13,8 @@ function emit(type, detail) { bus.dispatchEvent(new CustomEvent(type, { detail }
 
 // Shared <audio> element
 let el;
+let stopActivePlayback = null;
+
 function getEl() {
   if (!el) {
     el = new Audio();
@@ -66,10 +68,30 @@ async function playFromCandidates(label, candidates) {
 
     const ok = await new Promise((resolve) => {
       let guard = null;
+      let settled = false;
+
+      const cleanup = () => {
+        if (guard) { clearTimeout(guard); guard = null; }
+        a.onended = a.onerror = a.oncanplay = a.onloadedmetadata = null;
+        if (stopActivePlayback === cancelPlayback) stopActivePlayback = null;
+      };
+
+      const finish = (status, value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        try { a.pause(); } catch {}
+        try { a.currentTime = 0; } catch {}
+        if (status === "ended") emit("status", { who: label, status: "ended" });
+        resolve(value);
+      };
+
+      const cancelPlayback = () => finish("ended", true);
+      stopActivePlayback = cancelPlayback;
 
       a.onloadedmetadata = () => {
         const ms = isFinite(a.duration) && a.duration > 0 ? Math.min(15000, a.duration * 1000 + 1000) : 12000;
-        guard = setTimeout(() => resolve(true), ms); // safety if onended never fires
+        guard = setTimeout(() => finish("ended", true), ms); // safety if onended never fires
       };
 
       a.oncanplay = async () => {
@@ -78,16 +100,19 @@ async function playFromCandidates(label, candidates) {
           emit("status", { who: label, status: "playing", src });
         } catch (err) {
           lastErr = err;
-          resolve(false);
+          finish("error", false);
         }
       };
 
-      a.onended = () => { if (guard) clearTimeout(guard); emit("status", { who: label, status: "ended" }); resolve(true); };
-      a.onerror = () => resolve(false);
+      a.onended = () => finish("ended", true);
+      a.onerror = () => finish("error", false);
     });
 
     if (ok) return true;
   }
+
+  if (stopActivePlayback) stopActivePlayback = null;
+
   console.error(`[audio] failed for ${label}`, { lastErr, candidates });
   emit("status", { who: label, status: "error" });
   return false;
@@ -113,5 +138,14 @@ export function preloadCaptainCues(scnId, cues = []) {
 }
 
 export function stopAudio() {
-  try { getEl().pause(); } catch {}
+  if (typeof stopActivePlayback === "function") {
+    const cancel = stopActivePlayback;
+    stopActivePlayback = null;
+    cancel();
+    return;
+  }
+  const a = getEl();
+  try { a.pause(); } catch {}
+  try { a.currentTime = 0; } catch {}
+  emit("status", { who: "captain", status: "ended" });
 }


### PR DESCRIPTION
## Summary
- add a cancel hook for the shared captain audio element so manual stops fully reset playback and status updates
- ensure stopAudio cancels any active playback, rewinds the element, and emits an ended status for the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d331da597c832bb0deab80672c4326